### PR TITLE
Fix IndexOutOfBoundsException when returned kdb table has no rows

### DIFF
--- a/src/main/java/uk/co/aquaq/kdb/service/KdbService.java
+++ b/src/main/java/uk/co/aquaq/kdb/service/KdbService.java
@@ -104,7 +104,10 @@ public class KdbService {
 
     private void embedResults(List<Map<String, Object>> results, HashMap<String, Object> responseMap) {
         List<Map<String, Object>> completeResults = new ArrayList<>(results);
-        Object result=completeResults.get(0).get("result");
+        Object result = null;
+        if (!completeResults.isEmpty()) {
+            result=completeResults.get(0).get("result");
+        }
         results.clear();
         if(result!=null){
             responseMap.put("result",result);


### PR DESCRIPTION
When a query or function returns a kdb table (c.Flip) the completeResults will be a list of maps containing key-value pairs which should have no mapping for "result". The result will be null and the responseMap will put completeResults as the "result". Changes made prevents an IndexOutOfBoundsException while still returning a list (that's empty) when there are no rows in the kdb table from the response.